### PR TITLE
Ask for credentials when using Basic auth authentication

### DIFF
--- a/lib/middleware/auth.js
+++ b/lib/middleware/auth.js
@@ -21,6 +21,8 @@ module.exports = function(username, password) {
 
     if (unauthorized) {
       res.statusCode = 401;
+      res.set('WWW-Authenticate', 'Basic realm="Credentials required"');
+
       return res.end();
     }
 


### PR DESCRIPTION
I tried to use Basic auth over in [`aws-iam-proxy`](https://github.com/bugcrowd/aws-iam-proxy) but there was no way to enter the credentials so I checked the auth middleware and added the `WWW-Authenticate` header.

## Screenshots

### Chrome

<img width="447" alt="screen shot 2017-02-13 at 23 25 59" src="https://cloud.githubusercontent.com/assets/1086961/22906543/3a38b7c4-f245-11e6-95c3-3f74cc3ce87e.png">

### Firefox

<img width="525" alt="screen shot 2017-02-13 at 23 26 07" src="https://cloud.githubusercontent.com/assets/1086961/22906555/454e8904-f245-11e6-8722-0fe5e831e0c9.png">
